### PR TITLE
Make play hook work properly

### DIFF
--- a/hooks/play.lua
+++ b/hooks/play.lua
@@ -89,11 +89,12 @@ function RE.Play.Protocol.play(request, ok, err)
         return
     end
 
-    G.GAME.chips = G.GAME.blind.chips
-    G.STATE = G.STATES.HAND_PLAYED
-    G.STATE_COMPLETE = true
-    end_round()
+    -- G.GAME.chips = G.GAME.blind.chips
+    -- G.STATE = G.STATES.HAND_PLAYED
+    -- G.STATE_COMPLETE = true
+    -- end_round()
 
+    G.FUNCS.play_cards_from_highlighted(nil)
     RE.Screen.await({G.STATES.SELECTING_HAND, G.STATES.ROUND_EVAL, G.STATES.GAME_OVER}, function(new_state)
         if new_state == G.STATES.SELECTING_HAND then
             ok({Again = RE.Play.info()})


### PR DESCRIPTION
The play/play currently sets the score and ends the round.
This will return it to normal behavior from when it was changed in d4e8f7c.